### PR TITLE
Add module-info

### DIFF
--- a/src/main/java/module-info.java
+++ b/src/main/java/module-info.java
@@ -1,0 +1,7 @@
+module com.dashjoin.jsonata {
+    requires java.compiler;
+
+    exports com.dashjoin.jsonata;
+    exports com.dashjoin.jsonata.json;
+    exports com.dashjoin.jsonata.utils;
+}


### PR DESCRIPTION
addresses #7

The dependency on `java.compiler` seems to come from just one place in the code that can maybe be changed. Its also unclear whether the `.utils` package should be visible