### PR TITLE
Fix handling of nulls passed via context

### DIFF
--- a/src/main/java/com/dashjoin/jsonata/Jsonata.java
+++ b/src/main/java/com/dashjoin/jsonata/Jsonata.java
@@ -188,7 +188,7 @@ public class Jsonata {
                 result = evaluateRegex(expr); //, input, environment);
                 break;
             case "function":
-                result = /* await */ evaluateFunction(expr, input, environment, null);
+                result = /* await */ evaluateFunction(expr, input, environment, Utils.NONE);
                 break;
             case "variable":
                 result = evaluateVariable(expr, input, environment);
@@ -1514,11 +1514,6 @@ public class Jsonata {
 
         var lhs = /* await */ evaluate(expr.lhs, input, environment);
 
-        // Map null to NULL_VALUE before applying to functions
-        // TODO: fix more generically!
-        if (lhs==null)
-            lhs = Jsonata.NULL_VALUE;
-
         if(expr.rhs.type.equals("function")) {
         //Symbol applyTo = new Symbol(); applyTo.context = lhs;
             // this is a Object _invocation_; invoke it with lhs expression as the first argument
@@ -1608,7 +1603,7 @@ public class Jsonata {
  
         List<Object> evaluatedArgs = new ArrayList();
 
-         if (applytoContext != null) {
+         if (applytoContext != Utils.NONE) {
             evaluatedArgs.add(applytoContext);
          }
          // eager evaluation - evaluate the arguments

--- a/src/test/java/com/dashjoin/jsonata/StringTest.java
+++ b/src/test/java/com/dashjoin/jsonata/StringTest.java
@@ -73,6 +73,14 @@ public class StringTest {
   public void splitTest() {
     Object res;
 
+    // Splitting on an undefined value
+    res = jsonata("$split(a, '-')").evaluate(Map.of());
+    Assertions.assertNull(res);
+
+    // Splitting on an undefined value, equivalent to above
+    res = jsonata("a ~> $split('-')").evaluate(Map.of());
+    Assertions.assertNull(res);
+
     // Splitting empty string with empty separator must return empty list
     res = jsonata("$split('', '')").evaluate(null);
     Assertions.assertEquals(Arrays.asList(), res);


### PR DESCRIPTION
This is a port of the corresponding fix in the Python implementation of JSONata, see [this](https://github.com/rayokota/jsonata-python/issues/3).

The fix allows a null obtained from the context to be properly handled, so that the following two expressions return the same result (where `a` is undefined):

```
     jsonata("$split(a, '-')").evaluate(Map.of());

     jsonata("a ~> $split('-')").evaluate(Map.of());
```


    