### PR TITLE
Chain operator should respect array constructor

### DIFF
--- a/src/main/java/com/dashjoin/jsonata/Parser.java
+++ b/src/main/java/com/dashjoin/jsonata/Parser.java
@@ -1176,6 +1176,7 @@ public class Parser {
                         result = new Symbol(); result.type = "apply"; result.value = expr.value; result.position = expr.position;
                         result.lhs = processAST(expr.lhs);
                         result.rhs = processAST(expr.rhs);
+                        result.keepArray = result.lhs.keepArray || result.rhs.keepArray;
                         break;                    
                     default:
                         Infix _result = new Infix(null);


### PR DESCRIPTION
This is a port of the corresponding fix in[ jsonata-js](https://github.com/jsonata-js/jsonata/pull/714) and [jsonata-python](https://github.com/rayokota/jsonata-python/pull/7).

