### PR TITLE
make Parser.Symbol public to make implementation of EntryCallback and ExitCallback possible

### DIFF
--- a/src/main/java/com/dashjoin/jsonata/Parser.java
+++ b/src/main/java/com/dashjoin/jsonata/Parser.java
@@ -92,7 +92,7 @@ public class Parser {
         }
     }
     
-    class Symbol implements Cloneable {
+    public class Symbol implements Cloneable {
 
         //Symbol s;
         String id;


### PR DESCRIPTION
Hello,

Currently, it's impossible to implement `EntryCallback` and `ExitCallback` since Parser.Symbol is not public and can't be referenced outside `com.dashjoin.jsonata` package.