### PR TITLE
make public Parser.Symbol.type

### DIFF
--- a/src/main/java/com/dashjoin/jsonata/Parser.java
+++ b/src/main/java/com/dashjoin/jsonata/Parser.java
@@ -96,7 +96,7 @@ public class Parser {
 
         //Symbol s;
         String id;
-        String type;
+        public String type;
         Object value;
         int bp;
         int lbp;


### PR DESCRIPTION
Hello,

To make it easy to work with `Parser.Symbol` and state of expr, let's make `Parser.Symbol.type`  public.