### PR TITLE
Fix regexp which ends in /i or /m

### DIFF
--- a/src/test/java/com/dashjoin/jsonata/StringTest.java
+++ b/src/test/java/com/dashjoin/jsonata/StringTest.java
@@ -127,11 +127,4 @@ public class StringTest {
         + "  $eval('$data.Wert1')\n"
         + ")").evaluate(null));
   }
-  
-  @Disabled
-  @Test
-  public void replaceTest() {
-    Assertions.assertEquals("http://example.org/test", 
-        jsonata("$replace($, /{par}/, '')").evaluate("http://example.org/test{par}"));
-  }
 }


### PR DESCRIPTION
This is a port of the corresponding fix in [jsonata-python](https://github.com/rayokota/jsonata-python/issues/13)