### PR TITLE
fix wildcard handling

### DIFF
--- a/src/main/java/com/dashjoin/jsonata/Jsonata.java
+++ b/src/main/java/com/dashjoin/jsonata/Jsonata.java
@@ -723,9 +723,6 @@ public class Jsonata {
                 if((value instanceof List)) {
                     value = flatten(value, null);
                     results = (List)Functions.append(results, value);
-                } else if (value instanceof Map) {
-                // Call recursively do decompose the map
-                results.addAll((List)evaluateWildcard(expr, value));
                 } else {
                     results.add(value);
                 }

--- a/src/main/java/com/dashjoin/jsonata/Utils.java
+++ b/src/main/java/com/dashjoin/jsonata/Utils.java
@@ -79,11 +79,7 @@ public class Utils {
         JList<Object> sequence = new JList<>();
         sequence.sequence = true;
         if (el!=NONE) {
-            if (el instanceof List && ((List)el).size()==1)
-                sequence.add(((List)el).get(0));
-            else
-            // This case does NOT exist in Javascript! Why?
-                sequence.add(el);
+            sequence.add(el);
         }
         return sequence;
     }

--- a/src/test/java/com/dashjoin/jsonata/ArrayTest.java
+++ b/src/test/java/com/dashjoin/jsonata/ArrayTest.java
@@ -49,14 +49,12 @@ public class ArrayTest {
     Assertions.assertEquals(Arrays.asList(Map.of("x", 2), Map.of("x", 1)), expr.evaluate(null));
   }
 
-  @Disabled
   @Test
   public void testWildcard() {
     Jsonata expr = jsonata("*");
     Assertions.assertEquals(Map.of("x", 1), expr.evaluate(List.of(Map.of("x", 1))));
   }
 
-  @Disabled
   @Test
   public void testWildcardFilter() {
     Object value1 = Map.of("value", Map.of("Name", "Cell1", "Product", "Product1"));


### PR DESCRIPTION
JList is initialized with 0 or 1 arguments. The original is this:
        if (arguments.length === 1) {
            sequence.push(arguments[0]);
        }
If an argument is passed, it is added. The new code mimics this.

The second issue is in the wildard handling. In the list case, arrays need to be flattended. The issue comes from the unnecessary handling of maps. Like scalar types, those simply need to be added to the result