### PR TITLE
Fix index increment in Signature validation

### DIFF
--- a/src/main/java/com/dashjoin/jsonata/utils/Signature.java
+++ b/src/main/java/com/dashjoin/jsonata/utils/Signature.java
@@ -391,6 +391,7 @@ public class Signature implements Serializable {
                         }
                     }
                 }
+                index++;
             }
             return validatedArgs;
         }   

--- a/src/test/java/com/dashjoin/jsonata/SignatureTest.java
+++ b/src/test/java/com/dashjoin/jsonata/SignatureTest.java
@@ -55,4 +55,17 @@ public class SignatureTest {
     }, "<n+:n>"));
     Assertions.assertEquals(6, expression.evaluate(null));
   }
+
+  @Test
+  public void testVarArgMany(){
+      Jsonata expr = jsonata("$customArgs('test',[1,2,3,4],3)");
+      expr.registerFunction("customArgs", new JFunction(new JFunctionCallable() {
+
+          @Override
+          public Object call(Object input, @SuppressWarnings("rawtypes") List args) throws Throwable {
+              return args.toString();
+          }
+      }, "<sa<n>n:s>"));
+      Assertions.assertEquals("[test, [1, 2, 3, 4], 3]", expr.evaluate(null));
+  }
 }


### PR DESCRIPTION
Due to the fixed index (index = 0), always the first capturing group is selected.  This was creating a problem when the signature had different types parameters.