### PR TITLE
Update assertFn to use custom error message

### DIFF
--- a/src/main/java/com/dashjoin/jsonata/Functions.java
+++ b/src/main/java/com/dashjoin/jsonata/Functions.java
@@ -1891,7 +1891,7 @@ public class Functions {
      */
     public static void assertFn(boolean condition, String message) throws Throwable {
         if(!condition) {
-            throw new JException("D3141", -1, "$assert() statement failed");
+            throw new JException("D3141", -1, message!=null ? message : "$assert() statement failed");
 //                message: message || "$assert() statement failed"
         }
     }


### PR DESCRIPTION
`$assert` always returns a fixed error message: "$assert() statement failed", this PR fixes it so that it uses the user-defined message instead