### PR TITLE
fix: get a function from a class that is passed as a call attribute

### DIFF
--- a/src/main/java/com/dashjoin/jsonata/Functions.java
+++ b/src/main/java/com/dashjoin/jsonata/Functions.java
@@ -2142,7 +2142,7 @@ public class Functions {
     }
 
     public static Method getFunction(Class clz, String name) {
-        Method[] methods = Functions.class.getMethods();
+        Method[] methods = clz.getMethods();
         for (Method m : methods) {
             // if (m.getModifiers() == (Modifier.STATIC | Modifier.PUBLIC) ) {
             //     System.out.println(m.getName());


### PR DESCRIPTION
call fix mentioned in https://github.com/dashjoin/jsonata-java/issues/83