### PR TITLE
ISSUES-91: fix regex matcher body and next func

### DIFF
--- a/src/main/java/com/dashjoin/jsonata/Jsonata.java
+++ b/src/main/java/com/dashjoin/jsonata/Jsonata.java
@@ -37,6 +37,7 @@ import java.util.concurrent.Callable;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.function.Supplier;
+import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
@@ -1753,14 +1754,18 @@ public class Jsonata {
                 }
              } else if (proc instanceof Pattern) {
                 List _res = new ArrayList<>();
-                for (String s : (List<String>)validatedArgs) {
+                for (Object s : (List)validatedArgs) {
                 //System.err.println("PAT "+proc+" input "+s);
-                    if (((Pattern)proc).matcher(s).find()) {
-                        //System.err.println("MATCH");
-                        _res.add(s);
+                    if (s instanceof String) {
+                        Matcher matcher = ((Pattern) proc).matcher((String) s);
+                        _res.add(regexClosure(matcher));
                     }
                 }
-                result = _res;
+                if (_res.size() == 1) {
+                    result = _res.get(0);
+                } else {
+                    result = _res;
+                }
              } else {
                 System.out.println("Proc not found "+proc);
                  throw new JException(
@@ -1779,6 +1784,21 @@ public class Jsonata {
          }
          return result;
      }
+
+    private static Map regexClosure(Matcher matcher) {
+        if (matcher.find()) {
+            String group = matcher.group();
+            return Map.of(
+                    "match", group,
+                    "start", matcher.start(),
+                    "end", matcher.end(),
+                    "groups", List.of(group),
+                    "next", (Fn0<Map>) () -> regexClosure(matcher)
+            );
+        } else {
+            return null;
+        }
+    }
  
      /**
       * Evaluate lambda against input data

--- a/src/main/java/com/dashjoin/jsonata/Parser.java
+++ b/src/main/java/com/dashjoin/jsonata/Parser.java
@@ -998,7 +998,8 @@ public class Parser {
                             rest.procedure.type.equals("path") &&
                             rest.procedure.steps.size() == 1 &&
                             rest.procedure.steps.get(0).type.equals("name") &&
-                            result.steps.get(result.steps.size() - 1).type.equals("function")) {
+                            result.steps.get(result.steps.size() - 1).type.equals("function") &&
+                            rest.procedure.steps.get(0).value instanceof Symbol) {
                             // next function in chain of functions - will override a thenable
                             result.steps.get(result.steps.size() - 1).nextFunction = (Symbol)rest.procedure.steps.get(0).value;
                         }

--- a/src/test/java/com/dashjoin/jsonata/RegexTest.java
+++ b/src/test/java/com/dashjoin/jsonata/RegexTest.java
@@ -3,6 +3,9 @@ package com.dashjoin.jsonata;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
+import java.util.List;
+import java.util.Map;
+
 public class RegexTest {
     @Test
     public void testRegex() {
@@ -18,5 +21,37 @@ public class RegexTest {
         Object evaluate = expression.evaluate(null);
         String expected = "^test.*$";
         Assertions.assertEquals(expected, evaluate.toString());
+    }
+
+    @Test
+    public void testEvalRegexCheckAnswerData() {
+        var expression = Jsonata.jsonata(
+                "(\n" +
+                        "    $matcher := $eval('/l/');\n" +
+                        "    ('Hello World' ~> $matcher);\n" +
+                        ")"
+        );
+        Map<String, Object> evaluate = (Map<String, Object>)(expression.evaluate(null));
+        Assertions.assertEquals("l", evaluate.get("match"));
+        Assertions.assertEquals(2, evaluate.get("start"));
+        Assertions.assertEquals(3, evaluate.get("end"));
+        Assertions.assertEquals(List.of("l"), evaluate.get("groups"));
+        Assertions.assertInstanceOf(Jsonata.Fn0.class, evaluate.get("next"));
+    }
+
+    @Test
+    public void testEvalRegexCallNextAndCheckResult() {
+        var expression = Jsonata.jsonata(
+                "(\n" +
+                        "    $matcher := $eval('/l/');\n" +
+                        "    ('Hello World' ~> $matcher).next();\n" +
+                        ")"
+        );
+        Map<String, Object> evaluate = (Map<String, Object>)(expression.evaluate(null));
+        Assertions.assertEquals("l", evaluate.get("match"));
+        Assertions.assertEquals(3, evaluate.get("start"));
+        Assertions.assertEquals(4, evaluate.get("end"));
+        Assertions.assertEquals(List.of("l"), evaluate.get("groups"));
+        Assertions.assertInstanceOf(Jsonata.Fn0.class, evaluate.get("next"));
     }
 }


### PR DESCRIPTION
fix answer of regex and next functions invoke

add code in jsonata-java way 
jsonata-js way requared more time and more changes:
- change evaluateRegex to return function, not just pattern
- change dependent methods, like 'contains', 'split' and other 