### PR TITLE
fix: make Frame.lookup() iterative to prevent StackOverflowError

### DIFF
--- a/src/main/java/com/dashjoin/jsonata/Jsonata.java
+++ b/src/main/java/com/dashjoin/jsonata/Jsonata.java
@@ -89,12 +89,11 @@ public class Jsonata {
         public<A,B,R> void bind(String name, Fn2<A,B,R> lambda) { bind(name, (Object)lambda); }
 
         public Object lookup(String name) {
-            // Important: if we have a null value,
-            // return it
-            if (bindings.containsKey(name))
-                return bindings.get(name);
-            if (parent!=null)
-                return parent.lookup(name);
+            // Iterative walk of the parent scope chain to avoid StackOverflowError
+            // on JVMs with small thread stacks (e.g. Windows workers).
+            for (Frame f = this; f != null; f = f.parent) {
+                if (f.bindings.containsKey(name)) return f.bindings.get(name);
+            }
             return null;
         }
 


### PR DESCRIPTION
## Problem

`Jsonata$Frame.lookup()` walks the parent scope chain via tail recursion:

```java
Object lookup(String name) {
    if (bindings.containsKey(name)) return bindings.get(name);
    else if (parent != null) return parent.lookup(name);
    return null;
}
```

Java does not optimize tail calls. On JVMs with smaller default thread stack sizes (e.g. Windows workers, containers with `-Xss256k`), deeply nested JSONata expressions overflow the stack. The `StackOverflowError` is a JVM `Error`, not an `Exception` — it cannot be safely caught and recovered from, and it crashes the entire worker thread.

## Fix

Replace with an iterative loop. Identical semantics, zero recursion:

```java
Object lookup(String name) {
    for (Frame f = this; f != null; f = f.parent) {
        if (f.bindings.containsKey(name)) return f.bindings.get(name);
    }
    return null;
}
```

## Impact

- No behavior change — traversal order is identical
- Eliminates all stack risk from scope chain lookup regardless of depth
- Fixes worker crashes observed in Kestra's `plugin-transform-json` on Windows workers (reported at https://github.com/kestra-io/plugin-transform/pull/79)