### PR TITLE
Preserve JSON null when indexing into an array

### DIFF
--- a/src/main/java/com/dashjoin/jsonata/Jsonata.java
+++ b/src/main/java/com/dashjoin/jsonata/Jsonata.java
@@ -502,7 +502,10 @@ public class Jsonata {
         if( input instanceof JList && ((JList)input).tupleStream) {
             ((JList)results).tupleStream = true;
         }
-        if (!(input instanceof List)) { // isArray
+        if (input == null) {
+            // undefined input yields undefined output; skip filtering entirely
+            input = Utils.createSequence();
+        } else if (!(input instanceof List)) { // isArray
             input = Utils.createSequence(input);
         }
         if (predicate.type.equals("number")) {
@@ -511,8 +514,12 @@ public class Jsonata {
                 // count in from end of array
                 index = ((List)input).size() + index;
             }
-            var item = 0<=index && index<((List)input).size() ? ((List)input).get(index) : null;
-            if(item != null) {
+            if (0<=index && index<((List)input).size()) {
+                var item = ((List)input).get(index);
+                // Preserve JSON null at this index (vs. out-of-bounds, which is undefined)
+                if (item == null) {
+                    item = NULL_VALUE;
+                }
                 if(item instanceof List) {
                     results = (List)item;
                 } else {

--- a/src/test/java/com/dashjoin/jsonata/NullSafetyTest.java
+++ b/src/test/java/com/dashjoin/jsonata/NullSafetyTest.java
@@ -72,6 +72,18 @@ public class NullSafetyTest {
     }
     
     @Test
+    public void testArrayIndexPreservesNull() {
+        // Indexing into an array element that is JSON null must yield null,
+        // not be filtered out as if it were undefined.
+        Map<String, Object> data = Map.of("data", List.of(
+            Arrays.asList(1, null, 3),
+            Arrays.asList(2, null, 4),
+            Arrays.asList(3, null, 5)));
+        Object res = jsonata("[$map(data, function($row) { $row[1] })]").evaluate(data);
+        Assertions.assertEquals(Arrays.asList(null, null, null), res);
+    }
+
+    @Test
     public void testFilterNullLookup() {
       var x = Jsonata.jsonata("$filter($, function($v, $i, $a){$lookup($v, 'content')})").evaluate(
           Arrays.asList(Map.of("content", "some"), Map.of()));


### PR DESCRIPTION
`evaluate_filter` was treating an in-bounds array element that happens to be JSON `null` the same as an out-of-bounds access, so a numeric predicate like `$row[1]` would silently drop the element instead of returning `null`.

Port of equivalent [fix](https://github.com/rayokota/jsonata-python/pull/36) from `jsonata-python` 